### PR TITLE
fix: Move replicate to runtime dependency

### DIFF
--- a/packages/opentelemetry-instrumentation-replicate/pyproject.toml
+++ b/packages/opentelemetry-instrumentation-replicate/pyproject.toml
@@ -24,6 +24,7 @@ opentelemetry-api = "^1.28.0"
 opentelemetry-instrumentation = ">=0.50b0"
 opentelemetry-semantic-conventions = ">=0.50b0"
 opentelemetry-semantic-conventions-ai = "0.4.10"
+replicate = ">=0.23.1,<0.27.0"
 
 [tool.poetry.group.dev.dependencies]
 autopep8 = "^2.2.0"
@@ -37,7 +38,6 @@ pytest-sugar = "1.0.0"
 vcrpy = "^6.0.1"
 pytest-recording = "^0.13.1"
 opentelemetry-sdk = "^1.27.0"
-replicate = ">=0.23.1,<0.27.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
xref: https://github.com/conda-forge/opentelemetry-instrumentation-replicate-feedstock/pull/20

https://github.com/traceloop/openllmetry/blob/645426360910ce56d00894fc9c7feb47d5230953/packages/opentelemetry-instrumentation-replicate/opentelemetry/instrumentation/replicate/event_emitter.py#L19

```raw
import: 'opentelemetry.instrumentation.replicate'
Traceback (most recent call last):
  File "/home/conda/feedstock_root/build_artifacts/opentelemetry-instrumentation-replicate_1752448577076/test_tmp/run_test.py", line 2, in <module>
    import opentelemetry.instrumentation.replicate
  File "/home/conda/feedstock_root/build_artifacts/opentelemetry-instrumentation-replicate_1752448577076/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeh/lib/python3.9/site-packages/opentelemetry/instrumentation/replicate/__init__.py", line 11, in <module>
    from opentelemetry.instrumentation.replicate.event_emitter import (
  File "/home/conda/feedstock_root/build_artifacts/opentelemetry-instrumentation-replicate_1752448577076/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeh/lib/python3.9/site-packages/opentelemetry/instrumentation/replicate/event_emitter.py", line 19, in <module>
    from replicate.prediction import Prediction
ModuleNotFoundError: No module named 'replicate'
```

<!-- Thanks for submitting a PR! To make sure this gets merged quickly, make sure to check the following checkboxes. -->

- [ ] I have added tests that cover my changes.
- [ ] If adding a new instrumentation or changing an existing one, I've added screenshots from some observability platform showing the change.
- [x] PR name follows conventional commits format: `feat(instrumentation): ...` or `fix(instrumentation): ...`.
- [ ] (If applicable) I have updated the documentation accordingly.
